### PR TITLE
Dependencies fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@
 nose
 coverage
 #pypi-publisher
-numpy==1.11.2
-scipy==0.18.1
+numpy >= 1.11.2
+scipy >= 0.18.1


### PR DESCRIPTION
Otherwise it breaks your numpy installation (especially if you have a higher version) and causes python to crash at start