### PR TITLE
fix threshold_filter for low vals, MutableMapping patch

### DIFF
--- a/hrv/filters.py
+++ b/hrv/filters.py
@@ -213,7 +213,7 @@ def threshold_filter(rri, threshold="medium", local_median_size=5):
     # Apply filter in the beginning later
     for j in range(local_median_size, n_rri):
         slice_ = slice(j - local_median_size, j)
-        if rri[j] > (np.median(rri[slice_]) + threshold):
+        if abs(rri[j] - np.median(rri[slice_])) > threshold:
             rri_to_remove.append(j)
 
     first_idx = list(range(local_median_size + 1))

--- a/hrv/rri.py
+++ b/hrv/rri.py
@@ -15,7 +15,13 @@ Classes
 """
 
 import sys
-from collections import MutableMapping, defaultdict
+from collections import defaultdict
+# patch to import MutableMapping for python > 3.9
+try: 
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -91,6 +91,17 @@ class Filter(TestCase):
         np.testing.assert_almost_equal(rri_filt.values, expected_rri, decimal=2)
         np.testing.assert_almost_equal(rri_filt.time, expected_time, decimal=2)
 
+    def test_threshold_filter_low_values(self):
+        fake_rri = RRi([810, 830, 860, 865, 804, 510, 800], time=[0, 1, 2, 3, 4, 5, 6])
+
+        rri_filt = threshold_filter(fake_rri, threshold=250)
+        expected_rri = [810, 830, 860, 865, 804, 748.40625, 800]
+        expected_time = [0, 1, 2, 3, 4, 5, 6]
+
+        assert isinstance(rri_filt, RRi)
+        np.testing.assert_almost_equal(rri_filt.values, expected_rri, decimal=2)
+        np.testing.assert_almost_equal(rri_filt.time, expected_time, decimal=2)
+
     def test_threshold_filter_noise_in_the_beginning(self):
         fake_rri = RRi([810, 500, 860, 865, 804, 810, 800], time=[0, 1, 2, 3, 4, 5, 6])
 

--- a/tests/test_rri.py
+++ b/tests/test_rri.py
@@ -1,4 +1,8 @@
-from collections import MutableMapping
+# patch to import MutableMapping for python > 3.9
+try: 
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 from unittest import mock
 
 import matplotlib


### PR DESCRIPTION
Should fix the issues #30 (cf also the added test) and #31 